### PR TITLE
Cleans up readme, style changes for code blocks and etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Red Hat Summit 2018: 
-# Getting Hands On With Istio on OpenShift
-
-![Istio Logo](instructions/images/istio-logo.png)
+# Red Hat Summit 2019: 
+# Red Hat OpenShift Service Mesh in Action
 
 ## Purpose
 
@@ -30,72 +28,17 @@ your application. This proxy intercepts all network communication between your
 microservices microservices, and is configured and managed using Istio’s control
 plane functionality -- not your application code!
 
-### Fetch connect script
+Kiali is an observability console designed to provide operational insight
+into the behavior and performance of the service mesh as a whole.
 
-First, open a terminal and run the following commands:
+Jaeger is a utility for capturing distributed tracing information of requests
+as they travel throughout the mesh.
 
-~~~bash
-cd
-wget https://raw.githubusercontent.com/jamesfalkner/istio-lab-summit-2018/master/scripts/connect.sh
-~~~
+Prometheus and Grafana are used to capture metrics about the performance and
+behavior of the mesh.
 
-### Find your hostname
+These components combined together are the Red Hat OpenShift Service Mesh.
 
-In the browser, you had requested a lab environment. On that page, you were
-assigned a GUID (a 4-digit alphanumeric string). For example, `xxxx`.
-
-### Execute connect script
-
-To connect to your provisioned lab machine, run the following command:
-
-**MAKE SURE THAT YOU SUBSTITUTE `xxxx` FOR THE GUID THAT YOU WERE ASSIGNED**
-
-~~~bash
-cd
-bash connect.sh openshift-xxxx.rhpds.opentlc.com
-~~~
-
-Make sure you type _yes_ to complete the SSH connection.
-
-Once connected, your lab machine has several environment variables pre-defined,
-and has Istio added to your `$PATH`. You can confirm this is set correctly:
-
-~~~bash
-echo Istio Home: $ISTIO_HOME && \
-echo Istio Lab Content: $ISTIO_LAB_HOME && \
-echo Istio Lab Project Name: $ISTIO_LAB_PROJECT && \
-echo Path: $PATH
-~~~
-
-### Start OpenShift and install Istio
-All of the exercises in this lab will be performed as the `root` system user.
-First, escalate your privileges using the following `sudo` command: 
-
-**MAKE SURE THAT YOU EXECUTE THE SUDO COMMAND EXACTLY OR YOUR ENVIRONMENT
-VARIABLES WILL NOT PROPAGATE CORRECTLY**
-
-~~~bash
-sudo -E -i
-~~~
-
-Then, execute the following two commands which will start the local OpenShift
-environment and install Istio into it:
-
-~~~bash
-cd $ISTIO_LAB_HOME
-./scripts/start.sh
-~~~
-
-The start script will then output a URL for you to visit:
-
-~~~
---------------------
-Setup complete. Open the Lab Instructions in your browser: http://istio-workshop-guides.aa.bb.cc.dd.xip.io
---------------------
-~~~
-
-This is the URL for your customized lab guide that you will use for the rest of
-the lab. Please open that URL in your browser and continue from there.
 
 # Using this lab content elsewhere
 ## Deploy On OpenShift

--- a/instructions/acl.adoc
+++ b/instructions/acl.adoc
@@ -9,20 +9,24 @@ This module will provide instruction on how to configure whitelists and blacklis
 which control what services a service is able to access. 
 
 [IMPORTANT]
-.Before you start
+.Before Start
 ====
+You should have only the following virtualservices and destinationrules in
+the `istio-tutorial` namespace:
 
-You should only have the following virtualservices and destinationrules in the
- istio-tutorial namespace
-
-[source,bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get virtualservice
+----
+
+And you should see something like the following:
+
+----
 No resources found.
 
-oc -n istio-tutorial get virtualservices
-NAME       GATEWAYS             HOSTS     AGE
-customer   [customer-gateway]   [*]       4d2h
+NAME       GATEWAYS             HOSTS   AGE
+customer   [customer-gateway]   [*]     18h
 ----
 ====
 
@@ -33,27 +37,34 @@ The access control rules take some time to be applied and reflected. Be patient 
 
 [#whitelist]
 == Whitelist
-We’ll create a whitelist on the preference service to only allow requests to the recommendation service
-if the version is v1 or v3. Requests to the v2 version of the recommendation service will return a 404
-Not Found HTTP error code.
+We’ll create a whitelist on the preference service to only allow requests to
+the recommendation service if the version is v1 or v3. Requests to the v2
+version of the recommendation service will return a 404 Not Found HTTP error
+code.
 
 First, start generating traffic. 
 
-[source,bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+You will see something like:
+
+----
 customer => preference => recommendation v1 from '765d4bc49d-ddgg7': 2949
 customer => preference => recommendation v2 from '7679d466f8-2hwcd': 2950
 ----
 
 Now create the whitelist. 
-[source,bash]
+
+[source,bash,role="copypaste"]
 ----
 oc create -f http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-whitelist.yml
 ----
 
-To see how this is done, take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-whitelist.yml :
+To see how this is done, take a look at:
+http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-whitelist.yml
 
 [source, yaml]
 ----
@@ -87,7 +98,8 @@ spec:
     - preferencesource.listentry
 ----
 
-If you look at Kiali, you will notice that traffic is now making it to the v1 and v3 versions of the service, but not v2. 
+If you look at Kiali, you will notice that traffic is now making it to the v1
+and v3 versions of the service, but not v2.
 
 image::whitelist_v2_fail.png[]
 
@@ -95,38 +107,43 @@ image::whitelist_v2_fail.png[]
 [#whitelist-cleanup]
 == Cleanup
 
-[source, bash]
+[source,bash,role="copypaste"]
 ----
 oc delete -f http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-whitelist.yml
 ----
 
 [#blacklist]
 == Blacklist
-Whereas whitelists allow communication only to the listed hosts, blacklists deny traffic to the listed hosts. 
-We'll demonstrate this using a blacklist on version 3 of the recomemendation service. Any requests to v3 will
-a 403 Forbidden HTTP error code.
+Whereas whitelists allow communication only to the listed hosts, blacklists
+deny traffic to the listed hosts. We'll demonstrate this using a blacklist on
+version 3 of the recomemendation service. Any requests to v3 will a 403
+Forbidden HTTP error code.
 
 First, start generating traffic. 
 
-[source,bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+You will see something like:
+
+----
 customer => preference => recommendation v1 from '765d4bc49d-ddgg7': 2953
 customer => preference => recommendation v3 from '6d4bf9cff8-5nvw2': 834
 customer => preference => recommendation v2 from '7679d466f8-2hwcd': 2954
 customer => preference => recommendation v1 from '765d4bc49d-ddgg7': 2954
-
 ----
 
 Now, create the blacklist.
 
-[source, bash]
+[source,bash,role="copypaste"]
 ----
 oc create -f http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-blacklist.yml
 ----
 
-To see how this is done, take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-blacklist.yml :
+To see how this is done, take a look at:
+http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-blacklist.yml
 
 [source, yaml]
 ----
@@ -159,17 +176,15 @@ spec:
     instances: [ denycustomerrequests.checknothing ]
 ----
 
-If we look at Kiali, we can now see that requests to the v3 version of the service are failing.
+If we look at Kiali, we can now see that requests to the v3 version of the
+service are failing.
 
 image::blacklist_v3_blocked.png[]
-
-
-
 
 [#blacklist-cleanup]
 == Cleanup
 
-[source, bash]
+[source,bash,role="copypaste"]
 ----
 oc delete -f http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/acl-blacklist.yml
 ----

--- a/instructions/authentication.adoc
+++ b/instructions/authentication.adoc
@@ -1,27 +1,26 @@
 = Authentication with JWT and RBAC
-include::_attributes.adoc[]
-
-TBD
-
-:toc:
 
 == What we will learn in this module
-In this module, we are going to see how to enable authenticating end user with ServiceMesh.
-We will also see how to use the ServiceMesh authorization feature to provide access control for services in the mesh.
+In this module, we are going to see how to enable authenticating end user with Service Mesh.
+We will also see how to use the Service Mesh authorization feature to provide access control for services in the mesh.
 
 
 [IMPORTANT]
 .Before Start
 ====
-You should have only the following virtualservices and destinationrules in the `istio-tutorial` namespace
+You should have only the following virtualservices and destinationrules in
+the `istio-tutorial` namespace:
 
-[source, bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get virtualservice
+----
 
+And you should see something like the following:
+
+----
 No resources found.
-
-$ oc -n istio-tutorial get virtualservice
 
 NAME       GATEWAYS             HOSTS   AGE
 customer   [customer-gateway]   [*]     18h
@@ -33,11 +32,17 @@ customer   [customer-gateway]   [*]     18h
 
 Now it is time to enable end-user authentication.
 
-The first thing you need to do is validate that it is possible to communicate between all services without authentication.
+The first thing you need to do is validate that it is possible to communicate
+between all services without authentication.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
+
+With output like the following:
+
+----
 
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 26
 customer => preference => recommendation v2 from '74f48f4cbc-j7rfm': 27
@@ -49,9 +54,10 @@ customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 28
 ----
 
 You can create the end-user authentication policy. To see how this is done,
-take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/policy-jwt.yaml[policy-jwt.yaml]
+take a look at
+link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/policy-jwt.yaml[policy-jwt.yaml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
@@ -70,25 +76,34 @@ spec:
 
 And then run the following to deploy the policy:
 
-[source, bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/policy-jwt.yaml
+oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/policy-jwt.yaml
+----
 
+You will see something like:
+
+----
 policy.authentication.istio.io/jwt-example created
 ----
 
 Then let's run the curl again:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+And you will see something like:
+
+----
 Origin authentication failed.
 ----
 
 === Kiali's Graph
 
-Within the Kiali UI select the *Graph* option from the left hand navigation and then choose
+Within the Kiali UI select the *Graph* option from the left hand navigation
+and then choose
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -102,12 +117,14 @@ image::auth-fail.png[]
 
 Note the 100% failure rate from the end-user to customer
 
-Now the communication is not possible because the user has not been identified (provides a valid JWT token).
+Now the communication is not possible because the user has not been
+identified (provides a valid JWT token).
 
-To get a correct token, we need to pass the token in the http request. To see how this is done,
-take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/scripts/curl_customer_token.sh[curl_customer_token.sh]
+To get a correct token, we need to pass the token in the http request. To see
+how this is done, take a look at
+link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/scripts/curl_customer_token.sh[curl_customer_token.sh]
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/release-1.1/security/tools/jwt/samples/demo.jwt -s)
 while :; do curl --header "Authorization: Bearer $TOKEN" $INGRESS_GATEWAY -s ; done
@@ -115,10 +132,14 @@ while :; do curl --header "Authorization: Bearer $TOKEN" $INGRESS_GATEWAY -s ; d
 
 Then let's run the curl again, this time with the token.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer_token.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer_token.sh)
+----
 
+And you will see something like:
+
+----
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 27103
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 27140
 customer => preference => recommendation v2 from '74f48f4cbc-snwfm': 18439
@@ -131,7 +152,8 @@ customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 27142
 
 === Kiali's Graph
 
-Within the Kiali UI select the *Graph* option from the left hand navigation and then choose
+Within the Kiali UI select the *Graph* option from the left hand navigation
+and then choose
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -148,22 +170,27 @@ Note the 100% failure rate from the authenticated end-user to customer
 [#cleanup]
 === Clean Up
 
-[source, bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/policy-jwt.yaml
+oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/policy-jwt.yaml
+----
 
+You will see something like:
+
+----
 policy.authentication.istio.io "jwt-example" deleted
 ----
 
-= ServiceMesh Role Based Access Control (RBAC)
+= Service Mesh Role Based Access Control (RBAC)
 
 [#enabling-rbac]
 == Enabling RBAC
 
-The first thing to do is enable Istio Authorization by using `RbacConfig` object.
-To see how this is done, take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/authorization-enable-rbac.yml[authorization-enable-rbac.yml]
+The first thing to do is enable Istio Authorization by using `RbacConfig`
+object. To see how this is done, take a look at
+link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/authorization-enable-rbac.yml[authorization-enable-rbac.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: RbacConfig
@@ -177,10 +204,14 @@ spec:
 
 Run this command to deploy the RBAC:
 
-[source, bash,subs="+macros,+attributes"]
+[source, bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/authorization-enable-rbac.yml
+oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/authorization-enable-rbac.yml
+----
 
+You will see something like:
+
+----
 rbacconfig.rbac.istio.io/default created
 ----
 
@@ -188,16 +219,21 @@ Now RBAC is enabled on your mesh.
 
 Then let's run the curl to test the RBAC:
 
-[source,bash,subs="+macros,+attributes"]
+[source, bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+You will see something like:
+
+----
 RBAC: access denied
 ----
 
 === Kiali's Graph
 
-Within the Kiali UI select the *Graph* option from the left hand navigation and then choose
+Within the Kiali UI select the *Graph* option from the left hand navigation
+and then choose
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -211,15 +247,21 @@ image::rbac-fail.png[]
 
 Note the 100% failure rate due to denied RBAC
 
-By default, Istio uses a _deny by default_ strategy, meaning that nothing is permitted until you explicitly define access control policy to grant access to any service.
+By default, Istio uses a _deny by default_ strategy, meaning that nothing is
+permitted until you explicitly define access control policy to grant access
+to any service.
 
 [#grant-access]
 == Granting Access
 
-Let's grant access to any user to any service of our mesh (`customer`, `preference`, `recommendation`) only and only if the communication goes through `GET` method.
-To see how this is done, take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/namespace-rbac-policy.yml[namespace-rbac-policy.yml]
+Let's grant access to any user to any service of our mesh (`customer`,
+`preference`, `recommendation`) only and only if the communication goes
+through `GET` method.
 
-[source,bash,subs="+macros,+attributes"]
+To see how this is done, take a look at
+link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/namespace-rbac-policy.yml[namespace-rbac-policy.yml]
+
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: "rbac.istio.io/v1alpha1"
 kind: ServiceRole
@@ -246,25 +288,34 @@ spec:
     name: "service-viewer"
 ----
 
-Note the ServiceRole `service-viewer` is bound to the `istio-tutorial` namespace for all users (*)
-and limits access to the GET method for the three services.
+Note the ServiceRole `service-viewer` is bound to the `istio-tutorial`
+namespace for all users (*) and limits access to the GET method for the three
+services.
 
 Run this command to deploy the role and role binding:
 
-[source, bash,subs="+macros,+attributes"]
+[source, bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/namespace-rbac-policy.yml
+oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/namespace-rbac-policy.yml
+----
 
+You will see something like:
+
+----
 servicerole.rbac.istio.io/service-viewer created
 servicerolebinding.rbac.istio.io/bind-service-viewer created
 ----
 
 Let's send a request now:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+You will see something like:
+
+----
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 27224
 customer => preference => recommendation v2 from '74f48f4cbc-snwfm': 18522
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 27187
@@ -278,7 +329,8 @@ The communication now is possible.
 
 === Kiali's Graph
 
-Within the Kiali UI select the *Graph* option from the left hand navigation and then choose
+Within the Kiali UI select the *Graph* option from the left hand navigation
+and then choose:
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -290,23 +342,26 @@ Within the Kiali UI select the *Graph* option from the left hand navigation and 
 .Kiali Graph Allowed RBAC
 image::rbac-success.png[]
 
-Note the 100% success rate due to allowed RBAC
+Note the 100% success rate due to allowed RBAC.
 
 [#cleanup]
 == Clean Up
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/namespace-rbac-policy.yml
+oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/namespace-rbac-policy.yml
+oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/authorization-enable-rbac.yml
+----
 
+You will see something like:
+
+----
 servicerole.rbac.istio.io "service-viewer" deleted
 servicerolebinding.rbac.istio.io "bind-service-viewer" deleted
-
-$ oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/authorization-enable-rbac.yml
-
 rbacconfig.rbac.istio.io "default" deleted
 ----
 
 = What we learned in this module
-ServiceMesh provides the capability to authenticate end-users via JWT and to enforce service RBAC.
-Kiali provides the mechanism to visialize end-user authentication and RBAC failures.
+Service Mesh provides the capability to authenticate end-users via JWT and to
+enforce service RBAC. Kiali provides the mechanism to visialize end-user
+authentication and RBAC failures.

--- a/instructions/circuit-breaking.adoc
+++ b/instructions/circuit-breaking.adoc
@@ -12,15 +12,19 @@ circuit breaking. This module will also how to visualize these capabilities in K
 [IMPORTANT]
 .Before Start
 ====
-You should have only the following virtualservices and destinationrules in the `istio-tutorial` namespace
+You should have only the following virtualservices and destinationrules in
+the `istio-tutorial` namespace:
 
-[source, bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get virtualservice
+----
 
+And you should see something like the following:
+
+----
 No resources found.
-
-$ oc -n istio-tutorial get virtualservice
 
 NAME       GATEWAYS             HOSTS   AGE
 customer   [customer-gateway]   [*]     18h
@@ -30,24 +34,35 @@ customer   [customer-gateway]   [*]     18h
 [#retry]
 == Retry
 
-Instead of failing immediately, ServiceMesh will retry the Service N more times.
-We will make pod recommendation-v2 fail 100% of the time. Get one of the pod names from your system and replace on the following command accordingly:
+Instead of failing immediately, ServiceMesh will retry the Service N more
+times. We will make pod recommendation-v2 fail 100% of the time. Get one of
+the pod names from your system and replace on the following command
+accordingly:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s localhost:8080/misbehave
+oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s localhost:8080/misbehave
+----
 
+You will see something like:
+
+----
 Following requests to / will return a 503
 ----
 
 This is a special endpoint that will make our application return only `503`s.
 
-You will see it works every time because ServiceMesh will retry the recommendation service *automatically* and it will land on v1 or v3 only.
+You will see it works every time because ServiceMesh will retry the
+recommendation service *automatically* and it will land on v1 or v3 only.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
+ 
+You will see something like:
 
+----
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 5290
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 5279
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 5291
@@ -59,29 +74,39 @@ customer => preference => recommendation v3 from '588747fd55-m8mj9': 5293
 
 === Kiali's Graph
 
-In Kiali, go to `Graph`, select the `recommendation` square, and place the mouse over the red sign, like the picture bellow.
+In Kiali, go to `Graph`, select the `recommendation` square, and place the
+mouse over the red sign, like the picture bellow:
 
 [#img-503]
 .Kiali Graph Retry
 image:retry.png[]
 
-Note that recommendation v2 has no traffic logged, but the the client has a 100% success rate due to the retries.
+Note that recommendation v2 has no traffic logged, but the the client has a
+100% success rate due to the retries.
 
 Now, make the pod v2 behave well again:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s localhost:8080/behave
+oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s localhost:8080/behave
+----
 
+You will see something like:
+
+----
 Following requests to / will return 200
 ----
 
-The application is back to random load-balancing between v1, v2 and v3
+The application is back to random load-balancing between v1, v2 and v3.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+And again:
+
+----
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 5282
 customer => preference => recommendation v2 from '74f48f4cbc-j7rfm': 5267
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 5294
@@ -95,21 +120,29 @@ customer => preference => recommendation v2 from '74f48f4cbc-j7rfm': 5269
 [#timeout]
 == Timeout
 
-Now we will configure a service to wait only N seconds before giving up and failing.
-First, introduce some wait time in `recommendation v2` by making it a slow performer with a 3 second delay by running the command
+Now we will configure a service to wait only N seconds before giving up and
+failing.
 
-[source,bash,subs="+macros,+attributes"]
+First, introduce some wait time in `recommendation v2` by making it a slow
+performer with a 3 second delay by running the command
+
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=3
+oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=3
+----
 
+You will see something like:
+
+----
 Timeout has been set to 3 seconds
 ----
 
-Hit the customer endpoint a few times, to see the load-balancing between v1, v2 and v3 but with v2 taking a bit of time to respond
+Hit the customer endpoint a few times, to see the load-balancing between v1,
+v2 and v3 but with v2 taking a bit of time to respond
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
 ----
 
 [#img-timeout-v1]
@@ -125,7 +158,7 @@ Note the duration of v2 is 3s compared to the ms time of v1.
 Then add the timeout rule. To see how this is done,
 take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/virtual-service-recommendation-timeout.yml[virtual-service-recommendation-timeout.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -143,19 +176,29 @@ spec:
 
 Note the 1s timeout for the recommendation destination.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial create -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-timeout.yml
+oc -n istio-tutorial create -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-timeout.yml
+----
 
+You will see something like:
+
+----
 virtualservice.networking.istio.io/recommendation created
 ----
 
-You will see it return v1 after waiting about 1 second. You don't see v2 anymore, because the response from v2 expires after the timeout period and it is never returned.
+You will see it return v1 after waiting about 1 second. You don't see v2
+anymore, because the response from v2 expires after the timeout period and it
+is never returned.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
 
+And then:
+
+----
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 5304
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 5293
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 5305
@@ -170,25 +213,35 @@ customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 5296
 .Kiali Graph for Timeout Rule
 image:timeout.png[]
 
-Note that recommendation v2 now has a 100% failure rate due to the timeout rule
+Note that recommendation v2 now has a 100% failure rate due to the timeout
+rule.
 
 === Clean up
 
-Change the implementation of `v2` back to the image that responds without the delay of 3 seconds:
+Change the implementation of `v2` back to the image that responds without the
+delay of 3 seconds:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=0
+oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=0
+----
 
+You will see something like:
+
+----
 Timeout has been set to 0 seconds
 ----
 
 Then delete the virtual service created for timeout by:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial delete -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-timeout.yml
+oc -n istio-tutorial delete -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-timeout.yml
+----
 
+You will see something like:
+
+----
 virtualservice.networking.istio.io "recommendation" deleted
 ----
 
@@ -196,9 +249,10 @@ virtualservice.networking.istio.io "recommendation" deleted
 == Fail Fast with Max Connections and Max Pending Requests
 
 Let's use a 34/33/33 split of traffic.
+
 To see how this is done, take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/virtual-service-recommendation-split.yml[virtual-service-recommendation-split.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -243,20 +297,28 @@ spec:
 
 Note the weighting of the 3 recommendation destination versions.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial apply -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-split.yml
+oc -n istio-tutorial apply -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-split.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io/recommendation created
 virtualservice.networking.istio.io/recommendation created
 ----
 
 Let's perform a load test in our system:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/loadtest.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/loadtest.sh)
+----
 
+You will see something like:
+
+----
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 6388
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 6389
 customer => preference => recommendation v2 from '74f48f4cbc-bcntc': 334
@@ -280,18 +342,23 @@ Note all recommendation hits are in the ms range
 [#nocircuitbreaker]
 === Load test without circuit breaker
 
-Next, introduce some wait time in `recommendation v2` by making it a slow performer with a 3 second delay by running the command
+Next, introduce some wait time in `recommendation v2` by making it a slow
+performer with a 3 second delay by running the command:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=3
+oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=3
+----
 
+You will see something like:
+
+----
 Timeout has been set to 3 seconds
 ----
 
 Let's perform a load test in our system. We'll have 20 concurrent requests:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/loadtest.sh)
 ----
@@ -304,17 +371,20 @@ image:nocircuit-graph.png[]
 .Kiali Distributed Tracing for Fail Fast w/no Circuit Breaking
 image:nocircuit.png[]
 
-All of the requests to our system were successful, but 1/3 of the requests took longer time, as the `v2` instance/pod was a slow performer.
+All of the requests to our system were successful, but 1/3 of the requests
+took longer time, as the `v2` instance/pod was a slow performer.
 
 [#circuitbreaker]
 === Load test with circuit breaker
 
-But suppose that in a production system this 3s delay was caused by too many concurrent requests to the same instance/pod.
-We don't want multiple requests getting queued or making the instance/pod even slower. So we'll add a circuit breaker that
-will *open* whenever we have more than 1 request being handled by any instance/pod. To see how this is done,
-take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/destination-rule-recommendation_cb_policy_version_v2.yml[destination-rule-recommendation_cb_policy_version_v2.yml]
+But suppose that in a production system this 3s delay was caused by too many
+concurrent requests to the same instance/pod. We don't want multiple requests
+getting queued or making the instance/pod even slower. So we'll add a circuit
+breaker that will *open* whenever we have more than 1 request being handled
+by any instance/pod. To see how this is done, take a look at
+link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/destination-rule-recommendation_cb_policy_version_v2.yml[destination-rule-recommendation_cb_policy_version_v2.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -346,21 +416,30 @@ spec:
         version: v3
 ----
 
-Note the connection pool with a max of 1 pending request and a traffic policy where 100% of single consecutive errors fail.
+Note the connection pool with a max of 1 pending request and a traffic policy
+where 100% of single consecutive errors fail.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc apply -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/destination-rule-recommendation_cb_policy_version_v2.yml
+oc apply -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/destination-rule-recommendation_cb_policy_version_v2.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io/recommendation configured
 ----
 
 Now let's see what is the behavior of the system running some load again:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/loadtest.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/loadtest.sh)
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io/recommendation configured
 ----
 
@@ -368,28 +447,40 @@ destinationrule.networking.istio.io/recommendation configured
 .Kiali Graph Fail Fast w/Circuit Breaking
 image:circuit-graph.png[]
 
-You should see some some failures in the results. That's the circuit breaker being opened whenever ServiceMesh detects more than 1 pending request being handled by the instance/pod.
+You should see some some failures in the results. That's the circuit breaker
+being opened whenever ServiceMesh detects more than 1 pending request being
+handled by the instance/pod.
 
 === Clean up
 
-Change the implementation of `v2` back to the image that responds without the delay of 3 seconds:
+Change the implementation of `v2` back to the image that responds without the
+delay of 3 seconds:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=0
+oc exec -n istio-tutorial -c recommendation $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v2' -o jsonpath='{..metadata.name}') -- curl -s http://localhost:8080/timeout?timeout=0
+----
 
+You will see something like:
+
+----
 Timeout has been set to 0 seconds
 ----
 
 Then delete the virtual service created for circuit braking by:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial delete -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-split.yml
+oc -n istio-tutorial delete -f  https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-split.yml
+----
 
+You will see something like:
+
+----
 virtualservice.networking.istio.io "recommendation" deleted
 ----
 
 == What we learned in this module
-Service Mesh and Kiali provide the ability to configure, handle, and visualize service retry behavior, service timeouts,
-and service circuit breaking.
+Service Mesh and Kiali provide the ability to configure, handle, and
+visualize service retry behavior, service timeouts, and service circuit
+breaking.

--- a/instructions/fault-injection.adoc
+++ b/instructions/fault-injection.adoc
@@ -1,48 +1,68 @@
 = Fault Injection
 include::_attributes.adoc[]
 
-Apply some chaos engineering by throwing in some HTTP errors or network delays. Understanding failure scenarios is a critical aspect of microservices architecture (aka distributed computing)
+Apply some chaos engineering by throwing in some HTTP errors or network
+delays. Understanding failure scenarios is a critical aspect of microservices
+architecture (aka distributed computing).
 
 :toc:
 
 == What we will learn in this module
-This module will provide instruction on how to introduce service failures and delays to better understand, test, and design microservices
+This module will provide instruction on how to introduce service failures and
+delays to better understand, test, and design microservices.
 
 [IMPORTANT]
 .Before Start
 ====
-You should have only the following virtualservices and destinationrules in the `istio-tutorial` namespace
+You should have only the following virtualservices and destinationrules in
+the `istio-tutorial` namespace:
 
-[source, bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get virtualservice
+----
 
+And you should see something like the following:
+
+----
 No resources found.
-
-$ oc -n istio-tutorial get virtualservice
 
 NAME       GATEWAYS             HOSTS   AGE
 customer   [customer-gateway]   [*]     18h
 ----
-
 ====
 
 [#503error]
 == HTTP Error 503
 
-By default, recommendation v1, v2 and v3 are being randomly load-balanced as that is the default behavior in ServiceMesh
+By default, recommendation v1, v2 and v3 are being randomly load-balanced as
+that is the default behavior in Service Mesh.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial get pods -l app=recommendation
+oc -n istio-tutorial get pods -l app=recommendation
+----
 
+You will see something like:
+
+----
 NAME                                 READY   STATUS    RESTARTS   AGE
 recommendation-v1-7fbb8f794-ngw58    2/2     Running   0          21h
 recommendation-v2-77bc7bb94d-8wjxz   2/2     Running   0          17h
 recommendation-v3-5786cd744d-96q79   2/2     Running   0          17h
+----
 
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+Then, execute:
 
+[source,bash,subs="+macros,+attributes",role="copypaste"]
+----
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
+
+You will see something like:
+
+----
 customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 26
 customer => preference => recommendation v2 from '74f48f4cbc-j7rfm': 27
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 27
@@ -55,7 +75,7 @@ customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 28
 You can inject 503's, for approximately 50% of the requests. To see how this is done,
 take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/virtual-service-recommendation-503.yml[virtual-service-recommendation-503.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -103,24 +123,42 @@ spec:
 ---
 ----
 
-Note that this file creates 2 resources. First, a DestinationRule `recommendation` with
-subsets for v1, v2, and v3. Second, a VirtualService `recommendation` that splits traffic equally between
-v1, v2, and v3 but also introduces a 503 fault for 50% of the requests.
+Note that this file creates 2 resources. First, a DestinationRule
+`recommendation` with subsets for v1, v2, and v3. Second, a VirtualService
+`recommendation` that splits traffic equally between v1, v2, and v3 but also
+introduces a 503 fault for 50% of the requests.
 
-NOTE: You may not see the 503 failures at 50% from the client due to the retry behavior in the lab
-ServiceMesh environment. When the preference -> recommendation call fails it will be retried 3x. Thus there is
-a high probability that the client will not see a failure but you will see that the failure rate is
-accurately reflected in the Kiali console.
+[NOTE]
+====
+You may not see the 503 failures at 50% from the client due to the
+retry behavior in the lab ServiceMesh environment. When the preference ->
+recommendation call fails it will be retried 3x. Thus there is a high
+probability that the client will not see a failure but you will see that the
+failure rate is accurately reflected in the Kiali console.
+====
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-503.yml
+oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-503.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io/recommendation created
 virtualservice.networking.istio.io/recommendation created
+----
 
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+Then, execute:
 
+[source,bash,subs="+macros,+attributes",role="copypaste"]
+----
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+----
+
+You will see something like:
+
+----
 customer => preference => recommendation v2 from '74f48f4cbc-j7rfm': 76
 customer => Error: 503 - preference => Error: 503 - fault filter abort
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 82
@@ -135,7 +173,8 @@ customer => preference => recommendation v1 from '7f8755bb79-vjwq2': 78
 
 === Kiali's Graph
 
-Within the Kiali UI select the *Graph* option from the left hand navigation and then choose
+Within the Kiali UI select the *Graph* option from the left hand navigation
+and then choose:
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -147,14 +186,18 @@ Within the Kiali UI select the *Graph* option from the left hand navigation and 
 .Kiali Graph Showing 503 Failures
 image::503.png[]
 
-Note the 50% failure rate from preference to recommendation
+Note the 50% failure rate from preference to recommendation.
 
 === Clean up
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-503.yml
+oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-503.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io "recommendation" deleted
 virtualservice.networking.istio.io "recommendation" deleted
 ----
@@ -162,11 +205,13 @@ virtualservice.networking.istio.io "recommendation" deleted
 [#delay]
 == Delay
 
-The most insidious of possible distributed computing faults is not a "down" service but a
-service that is responding slowly, potentially causing a cascading failure in your network of services.
-To see how to inject such a delay, take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/virtual-service-recommendation-delay.yml[virtual-service-recommendation-delay.yml]
+The most insidious of possible distributed computing faults is not a "down"
+service but a service that is responding slowly, potentially causing a
+cascading failure in your network of services. To see how to inject such a
+delay, take a look at
+link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/virtual-service-recommendation-delay.yml[virtual-service-recommendation-delay.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -213,33 +258,49 @@ spec:
 ---
 ----
 
-Note that this file creates 2 resources. First, a DestinationRule `recommendation` with
-subsets for v1, v2, and v3. Second, a VirtualService `recommendation` that splits traffic equally between
-v1, v2, and v3 but also introduces a 7s delay for 50% of the requests.
+Note that this file creates 2 resources. First, a DestinationRule
+`recommendation` with subsets for v1, v2, and v3. Second, a VirtualService
+`recommendation` that splits traffic equally between v1, v2, and v3 but also
+introduces a 7s delay for 50% of the requests.
 
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-delay.yml
+oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-delay.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io/recommendation created
 virtualservice.networking.istio.io/recommendation created
 ----
 
-And hit the customer endpoint
+And hit the customer endpoint:
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
+bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
 ----
 
-You will notice many requests to the customer endpoint now have a delay.
-If you are monitoring the logs for recommendation v1, v2 and v3, you will also see the delay happens BEFORE the recommendation service is actually called
+You will notice many requests to the customer endpoint now have a delay. If
+you are monitoring the logs for recommendation v1, v2 and v3, you will also
+see the delay happens BEFORE the recommendation service is actually called.
 
-[source,bash,subs="+macros,+attributes"]
+//TODO: switch to automated command
+[NOTE]
+====
+Use `oc get pods -n istio-tutorial` to find the `recommendation` pods to look at the logs.
+====
+
+[source,bash,subs="+macros,+attributes",role="copypaste copypaste-warning"]
 ----
-$ oc -n istio-tutorial logs -f recommendation-v#-XXXXXXXXXXXX -c recommendation
+oc -n istio-tutorial logs -f recommendation-v#-XXXXXXXXXXXX -c recommendation
+----
 
+You will see something like:
+
+----
 Apr 26, 2019 9:31:09 PM com.redhat.developer.demos.recommendation.rest.RecommendationResource getRecommendations
 INFO: recommendation request from 7fbb8f794-ngw58: 8334
 Apr 26, 2019 9:31:17 PM com.redhat.developer.demos.recommendation.rest.RecommendationResource getRecommendations
@@ -248,7 +309,8 @@ INFO: recommendation request from 7fbb8f794-ngw58: 8335
 
 === Kiali's Distributed Tracing
 
-Within the Kiali UI select the *Distributed Tracing* option from the left hand navigation and then choose
+Within the Kiali UI select the *Distributed Tracing* option from the left
+hand navigation and then choose:
 
 * Namespace: istio-tutorial
 * Service: recommendation.istio-tutorial
@@ -259,19 +321,25 @@ and finally press the *Search* button.
 .Kiali Graph Showing Delays
 image::delay.png[]
 
-Note that 50% of the traces are slightly over the artificial 7s delay while the other 50% are in the low ms range
+Note that 50% of the traces are slightly over the artificial 7s delay while
+the other 50% are in the low ms range.
 
 === Clean up
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-delay.yml
+oc -n istio-tutorial delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/virtual-service-recommendation-delay.yml
+----
+ 
+You will see something like:
 
+----
 destinationrule.networking.istio.io "recommendation" deleted
 virtualservice.networking.istio.io "recommendation" deleted
 ----
 
 == What we learned in this module
-ServiceMesh provides a simple mechanism to simulate service and network failures and delays to improve
-microservice testing and resiliency. Kiali provides a rich console to
-visualize the service failure rates and service delays.
+ServiceMesh provides a simple mechanism to simulate service and network
+failures and delays to improve microservice testing and resiliency. Kiali
+provides a rich console to visualize the service failure rates and service
+delays.

--- a/instructions/intro.adoc
+++ b/instructions/intro.adoc
@@ -1,16 +1,86 @@
 # TEB93D - Red Hat OpenShift Service Mesh in Action
-Thank you for signing up for an attending the lab on Red Hat OpenShift Service Mesh.
+
+## Purpose
+
+As microservices-based applications become more prevalent, both the number of
+and complexity of their interactions increases. Up until now much of the burden
+of managing these complex microservices interactions has been placed on the
+application developer, with different or non-existent support for microservice
+concepts depending on language and framework.
+
+The service mesh concept pushes this responsibility to the infrastructure, with
+features for traffic management, distributed tracing and observability, policy
+enforcement, and service/identity security, freeing the developer to focus on
+business value. In this hands-on session you will learn how to apply some of
+these features to a simple polyglot microservices application running on top of
+OpenShift using Istio, an open platform to connect, manage, and secure
+microservices.
+
+## Background
+
+Istio is an open platform to connect, manage, and secure microservices. Istio
+provides an easy way to create a network of deployed services with load
+balancing, service-to-service authentication, monitoring, and more, without
+requiring any changes in application code. OpenShift can automatically inject a
+special sidecar proxy throughout your environment to enable Istio management for
+your application. This proxy intercepts all network communication between your
+microservices microservices, and is configured and managed using Istio’s control
+plane functionality -- not your application code!
+
+Kiali is an observability console designed to provide operational insight
+into the behavior and performance of the service mesh as a whole.
+
+Jaeger is a utility for capturing distributed tracing information of requests
+as they travel throughout the mesh.
+
+Prometheus and Grafana are used to capture metrics about the performance and
+behavior of the mesh.
+
+These components combined together are the Red Hat OpenShift Service Mesh.
+
+## Conventions
+You will see various code and command blocks throughout these exercises. Some of
+the command blocks can be copy/pasted directly. Others will require modification
+of the command before execution. If you see a command block with a red border
+(see below), the command will require slight modification.
+
+[source,none,role="copypaste copypaste-warning"]
+----
+some command to modify
+----
+
+Most command blocks support auto highlighting with a click. If you hover over
+the command block above and left-click, it should automatically highlight all the
+text to make for easier copying.
 
 ## Getting Started
-The machine you are sitting at has the OpenShift CLI installed. Since the
-Service Mesh lab is running against OpenShift Container Platform 4, you will
-need to use `oc4` to interact with the API server.
+The machine you are sitting at has the OpenShift CLI installed. But these
+machines have OpenShift 3 and OpenShift 4 clients installed simultaneously as
+`oc3` and `oc4`, respectively. In order to make the commands work as
+described in these labs, please alias the `oc4` command in any terminals you
+open:
+
+[source,bash,role="copypaste"]
+----
+alias oc=oc4
+----
+
+You can verify it is working by simply typing:
+
+[source,bash,role="copypaste"]
+----
+oc version
+----
+
+The Service Mesh control plane is already deployed with several application
+components in an OpenShift Container Platform 4 environment. You will need to
+use `oc` to interact with the API server.
 
 You can login using the following command:
 
 [source,bash,role="copypaste"]
 ----
-oc4 login -u kubeadmin -p {{ KUBEADMIN_PASSWORD }} {{ API_URL }}
+oc login -u kubeadmin -p {{ KUBEADMIN_PASSWORD }} {{ API_URL }}
 ----
 
 The OpenShift Web Console is also available to you at the following URL:
@@ -26,5 +96,3 @@ You can login with:
 Username: kubeadmin
 Password: {{ KUBEADMIN_PASSWORD }}
 ----
-
-Now you are ready for the first lab. Click **Go To Next Module** to continue!

--- a/instructions/kiali.adoc
+++ b/instructions/kiali.adoc
@@ -1,29 +1,47 @@
 = Observing the Service Mesh using Kiali
 
-Applications deployed within the Service Mesh are able to take advantage of the builtin tracing and monitoring features present in the control plane.  These features provide an invaluable insight into the organisation and operation of the application as well as the application's performance.
+Applications deployed within the Service Mesh are able to take advantage of
+the builtin tracing and monitoring features present in the control plane.
+These features provide an invaluable insight into the organisation and
+operation of the application as well as the application's performance.
 
 == What we will learn in this module
 
-This module will provide a brief introduction to the Kiali observability component within the Service Mesh control plane.
+This module will provide a brief introduction to the Kiali observability
+component within the Service Mesh control plane.
 
 == Kiali
 
-link:http://kiali.io[Kiali] is a component which visualises an application's topology, health, metrics and tracing information to provide a deeper understanding of the application's behaviour and performance.  Within a single view it is easy to determine which services are communicating with each other, where the traffic is flowing, information about the current health of the service and other useful metrics.
+link:http://kiali.io[Kiali] is a component which visualises an application's
+topology, health, metrics and tracing information to provide a deeper
+understanding of the application's behaviour and performance. Within a single
+view it is easy to determine which services are communicating with each
+other, where the traffic is flowing, information about the current health of
+the service and other useful metrics.
 
-Kiali also integrates with Jaeger to provide access to distributed tracing information, allowing you to track an individual request as it flows through the system and identify potential issues.
+Kiali also integrates with Jaeger to provide access to distributed tracing
+information, allowing you to track an individual request as it flows through
+the system and identify potential issues.
 
 === How does Kiali work?
 
-Every pod deployed as part of the Service Mesh contains a proxy container responsible for intercepting the application traffic coming into and going out of the pod.  The Service Mesh proxy is automatically created on deployment of the application and automatically captures information as part of each service invocation.  Kiali uses this information to provide a visualisation of the Service Mesh behaviour.  The information includes metrics as well as distributed tracing information.
+Every pod deployed as part of the Service Mesh contains a proxy container
+responsible for intercepting the application traffic coming into and going
+out of the pod. The Service Mesh proxy is automatically created on deployment
+of the application and automatically captures information as part of each
+service invocation. Kiali uses this information to provide a visualisation of
+the Service Mesh behaviour. The information includes metrics as well as
+distributed tracing information.
 
 === Generating load
 
-Before we take a look at the Kiali console lets first generate some load on the Service Mesh.  From within a new terminal enter the following commands
+Before we take a look at the Kiali console lets first generate some load on
+the Service Mesh. From within a new terminal enter the following commands
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ export INGRESS_GATEWAY=$(oc get route -n istio-system istio-ingressgateway -o 'jsonpath={.spec.host}')
-$ while : ; do curl http://${INGRESS_GATEWAY}/ ; sleep 1 ; done
+export INGRESS_GATEWAY=$(oc get route -n istio-system istio-ingressgateway -o 'jsonpath={.spec.host}')
+while : ; do curl http://${INGRESS_GATEWAY}/ ; sleep 1 ; done
 ----
 
 === Opening the Kiali console
@@ -39,7 +57,8 @@ When prompted to login use the username *admin* and the password *admin*.
 
 === Kiali's Graph
 
-Within the Kiali UI select the _Graph_ option from the left hand navigation and then choose
+Within the Kiali UI select the _Graph_ option from the left hand navigation
+and then choose
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -49,13 +68,19 @@ Within the Kiali UI select the _Graph_ option from the left hand navigation and 
 
 image:kiali-graph-1.png[Kiali Graph showing configuration]
 
-You should now see the application graph showing traffic being created by our script generating load.  The traffic will flow from the Service Mesh ingress gateway to the customer service, preference service and finally the recommendation service.  The request percentage will show _100%_ on each edge except within the recommendation service where the traffic should be split evenly across all three versions.
+You should now see the application graph showing traffic being created by our
+script generating load. The traffic will flow from the Service Mesh ingress
+gateway to the customer service, preference service and finally the
+recommendation service. The request percentage will show _100%_ on each edge
+except within the recommendation service where the traffic should be split
+evenly across all three versions.
 
 image:kiali-graph-2.png[Kiali Graph showing application traffic]
 
 === Kiali's Distributed Tracing
 
-Within the Kiali UI select the _Distributed Tracing_ option from the left hand navigation and then choose
+Within the Kiali UI select the _Distributed Tracing_ option from the left
+hand navigation and then choose
 
 * Namespace: istio-tutorial
 * Service: customer.istio-tutorial
@@ -68,7 +93,10 @@ You should now see a list of the 20 most recent invocations of the customer serv
 
 image:kiali-tracing-2.png[Kiali Tracing showing invocations]
 
-Select one of the invocations to see more information.  The graph should now show a hierarchy of the invocations with those spans highlighted in _red_ automatically captured by the Service Mesh proxy, both client and server side, and the remainder provided by the application.
+Select one of the invocations to see more information. The graph should now
+show a hierarchy of the invocations with those spans highlighted in _red_
+automatically captured by the Service Mesh proxy, both client and server
+side, and the remainder provided by the application.
 
 image:kiali-tracing-3.png[Kiali Tracing showing detailed invocation]
 
@@ -78,12 +106,23 @@ image:kiali-tracing-4.png[Kiali Tracing showing context inforamation]
 
 === Cleaning up
 
-Switch back to the terminal with the script we used to generate load and press the ctrl+c keys to terminate the script.
+Switch back to the terminal with the script we used to generate load and
+press the ctrl+c keys to terminate the script.
 
 == What we learned in this module
 
-Kiali is a very useful tool for visualising the behaviour of your Service Mesh.  Through one UI you not only have a consistent view of your service interactions but you can see more detailed information about those invocations helping you to understand and identify potential issues which may arise.
+Kiali is a very useful tool for visualising the behaviour of your Service
+Mesh. Through one UI you not only have a consistent view of your service
+interactions but you can see more detailed information about those
+invocations helping you to understand and identify potential issues which may
+arise.
 
-With an understanding of Kiali you should now be able to make use of its capabilities within the following modules to visualise the changes in behaviour we will make through the resources within the Service Mesh framework.  Please keep your Kiali UI open as you work through the following modules.
+With an understanding of Kiali you should now be able to make use of its
+capabilities within the following modules to visualise the changes in
+behaviour we will make through the resources within the Service Mesh
+framework. Please keep your Kiali UI open as you work through the following
+modules.
 
-Kiali provides additional capabilities beyond what we have explored in this module, for more information refer to the link:http://kiali.io[Kiali website].
+Kiali provides additional capabilities beyond what we have explored in this
+module, for more information refer to the link:http://kiali.io[Kiali
+website].

--- a/instructions/mtls.adoc
+++ b/instructions/mtls.adoc
@@ -9,33 +9,42 @@ This module will provide instruction on how to enable Mutual TLS to secure commu
  between services in the mesh.
 
 [IMPORTANT]
-.Before you start
+.Before Start
 ====
+You should have only the following virtualservices and destinationrules in
+the `istio-tutorial` namespace:
 
-You should only have the following virtual services and destination rules in the istio-tutorial namespace
-
-[source,bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get virtualservice
+----
+
+And you should see something like the following:
+
+----
 No resources found.
 
-oc -n istio-tutorial get virtualservices
-NAME       GATEWAYS             HOSTS     AGE
-customer   [customer-gateway]   [*]       4d2h
+NAME       GATEWAYS             HOSTS   AGE
+customer   [customer-gateway]   [*]     18h
 ----
 ====
 
 [#enablemtls]
 == Enabling Mutual TLS
-For this example, we will take advantage of another pod that is outside of the service mesh. Let's grab that and the customer pod in a variable.
+For this example, we will take advantage of another pod that is outside of
+the service mesh. Let's grab that and the customer pod in a variable.
 
+Examine the traffic between the curl and customer services and the preference service:
 
-Examine the traffic between the curl and customer services and the preference service. 
-
-[source, bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer_preference.sh)
+----
 
+You will see something like:
+
+----
 Executing curl in curl pod
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
@@ -59,7 +68,9 @@ Executing curl in curl pod
 
 _Kiali’s Graph_
 
-Within the Kiali UI select the Graph option from the left hand navigation and then choose
+Within the Kiali UI select the Graph option from the left hand navigation and
+then choose:
+
 * Namespace: istio-tutorial
 * Versioned app graph
 * Requests percentage
@@ -67,13 +78,14 @@ Within the Kiali UI select the Graph option from the left hand navigation and th
 * Every 10s
 * Security checked under display
 
-Notice that both requests were successful. In the Kiali graph, this can be seen from the green line.
+Notice that both requests were successful. In the Kiali graph, this can be
+seen from the green line.
 
 image::mtls_initial.png[]
 
 Now configure preference to use mutual TLS policy. 
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
 oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/authentication-enable-tls.yml
 ----
@@ -98,9 +110,14 @@ spec:
 And try the curl again.
 
 
-[source, bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer_preference.sh)
+----
+
+And again:
+
+----
 
 Executing curl in curl pod
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -126,15 +143,17 @@ Executing curl in customer pod
 ----
 
 This time, we can see that the curl failed with exit code 56. This is because
- preference is now requiring encrypted communication over  mutual TLS, but neither customer nor curl are using it.
+preference is now requiring encrypted communication over mutual TLS, but
+neither customer nor curl are using it.
 
 We can see the same thing in Kiali. 
 
 image::mtls_no_destination_rule.png[]
 
-Now create a destination rule to make communication to customer use mutual TLS and run the curl again.
+Now create a destination rule to make communication to customer use mutual
+TLS and run the curl again.
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
 oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/destination-rule-tls.yml
 ----
@@ -154,9 +173,16 @@ spec:
       mode: ISTIO_MUTUAL
 ----
 
-[source, bash]
+Execute the curl script:
+
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer_preference.sh)
+----
+
+And again:
+
+----
 
 Executing curl in customer pod
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -188,32 +214,38 @@ Executing curl in customer pod
 100    62  100    62    0     0preference => recommendation v1 from '765d4bc49d-ddgg7': 117
 ----
 
-This time, we can see that because customer is part of the mesh, the request is successful. Since preference isn't, that still fails. 
+This time, we can see that because customer is part of the mesh, the request
+is successful. Since preference isn't, that still fails.
 
-Looking at the Kiali graph, a lock is now present for communicationbetween customer and preference, indicating that this communication is secured via mTLS.
+Looking at the Kiali graph, a lock is now present for communicationbetween
+customer and preference, indicating that this communication is secured via
+mTLS.
 
 image::mtls_policy_and_rule.png[]
 
 [#mtlsmigration]
 == mTLS migration
 
-Mutual TLS in OpenShift Service Mesh provides the ability to migrate to mTLS gradually rather than forcing all services to migrate to mTLS at once. Lets try that now. 
+Mutual TLS in OpenShift Service Mesh provides the ability to migrate to mTLS
+gradually rather than forcing all services to migrate to mTLS at once. Lets
+try that now.
 
 First, delete the policy we created above.
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
 oc delete policy -n istio-tutorial preference-mutualtls
 ----
 
 Now create a policy using permissive mode. 
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
 oc -n istio-tutorial create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/policy-permissive-tls.yml
 ----
 
-The contents of the file are displayed below.
+The contents of the file are displayed below:
+
 [source,yaml]
 ----
 apiVersion: "authentication.istio.io/v1alpha1"
@@ -229,11 +261,16 @@ spec:
       mode: PERMISSIVE
 ----
 
-If we try our curl commands again, we notice that this time they both pass. 
+If we try our curl commands again, we notice that this time they both pass:
 
-[source, bash]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer_preference.sh)
+----
+
+And again:
+
+----
 
 executing curl in curl pod
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                           
@@ -259,7 +296,9 @@ Executing curl in customer pod
   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0preference => recommendation v2 from '7679d466f8-2hwcd': 130
 ----
 
-In Kiali, we can see that the lock is still shown, indicating the presence of mTLS. We see the curl pod labeled as unknown since it's not part of the mesh, and we can see that both customer and curl are succesful.
+In Kiali, we can see that the lock is still shown, indicating the presence of
+mTLS. We see the curl pod labeled as unknown since it's not part of the mesh,
+and we can see that both customer and curl are succesful.
 
 image::mtls_permissive.png[]
 
@@ -268,7 +307,7 @@ image::mtls_permissive.png[]
 
 To cleanup, delete both the policy and destination rule that we created. 
 
-[source, bash]
+[source,bash,role="copypaste"]
 ----
 oc delete policy -n istio-tutorial preference-mutualtls
 oc delete destinationrule -n istio-tutorial preference-destination-rule

--- a/instructions/rate-limiting.adoc
+++ b/instructions/rate-limiting.adoc
@@ -12,15 +12,19 @@ terms of requests per time period.
 [IMPORTANT]
 .Before Start
 ====
-You should have only the following virtualservices and destinationrules in the `istio-tutorial` namespace
+You should have only the following virtualservices and destinationrules in
+the `istio-tutorial` namespace:
 
-[source, bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get destinationrule
+oc -n istio-tutorial get virtualservice
+----
 
+And you should see something like the following:
+
+----
 No resources found.
-
-$ oc -n istio-tutorial get virtualservice
 
 NAME       GATEWAYS             HOSTS   AGE
 customer   [customer-gateway]   [*]     18h
@@ -37,7 +41,7 @@ Here we will limit the number of concurrent requests into recommendation v2
 Now apply the rate limiting. To see how this is done,
 take a look at link:http://github.com/thoraxe/istio-lab-summit-2019/blob/master/src/istiofiles/recommendation_rate_limit.yml[recommendation_rate_limit.yml]
 
-[source,bash,subs="+macros,+attributes"]
+[source,yaml,subs="+macros,+attributes"]
 ----
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -127,13 +131,18 @@ spec:
     - requestcount.quota
 ----
 
-Note that the memquota resource `handler` defaines a rate limit of 4 requests per 5 seconds for the `recommendation`
-destination. Next, deploy the rate limiting resources.
+Note that the memquota resource `handler` defaines a rate limit of 4 requests
+per 5 seconds for the `recommendation` destination. Next, deploy the rate
+limiting resources.
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/recommendation_rate_limit.yml
+oc create -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/recommendation_rate_limit.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io/recommendation created
 memquota.config.istio.io/handler created
 quota.config.istio.io/requestcount created
@@ -144,14 +153,13 @@ rule.config.istio.io/quota created
 
 Throw some requests at customer:
 
-[source, bash,subs="+macros,+attributes"]
+[source, bash,subs="+macros,+attributes",role="copypaste"]
 ----
 bash <(curl -s https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/scripts/curl_customer.sh)
 ----
 
 You should see some 429 errors indicating the quota has been exhausted.
 
-[source,bash,subs="+macros,+attributes"]
 ----
 customer => preference => recommendation v2 from '74f48f4cbc-j7rfm': 2944
 customer => preference => recommendation v3 from '588747fd55-m8mj9': 2962
@@ -174,7 +182,8 @@ customer => Error: 503 - preference => Error: 429 - RESOURCE_EXHAUSTED:Quota is 
 
 === Kiali's Graph
 
-Within the Kiali UI select the *Graph* option from the left hand navigation and then choose
+Within the Kiali UI select the *Graph* option from the left hand navigation
+and then choose
 
 * Namespace: istio-tutorial
 * Versioned app graph
@@ -186,14 +195,18 @@ Within the Kiali UI select the *Graph* option from the left hand navigation and 
 .Kiali Graph Showing Rate Limited Failures
 image::rate.png[]
 
-Note the rate limited failure rate from preference to recommendation
+Note the rate limited failure rate from preference to recommendation.
 
 === Clean up
 
-[source,bash,subs="+macros,+attributes"]
+[source,bash,subs="+macros,+attributes",role="copypaste"]
 ----
-$ oc delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/recommendation_rate_limit.yml
+oc delete -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/recommendation_rate_limit.yml
+----
 
+You will see something like:
+
+----
 destinationrule.networking.istio.io "recommendation" deleted
 memquota.config.istio.io "handler" deleted
 quota.config.istio.io "requestcount" deleted
@@ -203,5 +216,6 @@ rule.config.istio.io "quota" deleted
 ----
 
 == What we learned in this module
-ServiceMesh provides a simple mechanism to dynamically limit the traffic to a particular service or version of a service.
-Kiali provides a rich console to visualize the service failures due to traffic exceeding those limits.
+ServiceMesh provides a simple mechanism to dynamically limit the traffic to a
+particular service or version of a service. Kiali provides a rich console to
+visualize the service failures due to traffic exceeding those limits.

--- a/instructions/routing.adoc
+++ b/instructions/routing.adoc
@@ -1,20 +1,32 @@
 = Routing within the Service Mesh
 
-One of the advantages of using a Service Mesh is the ability to modify the behaviour of your application's traffic without requiring code changes.  This change in behaviour is handled declaratively through the use of the Service Mesh custom resources.
+One of the advantages of using a Service Mesh is the ability to modify the
+behaviour of your application's traffic without requiring code changes. This
+change in behaviour is handled declaratively through the use of the Service
+Mesh custom resources.
 
 == What we will learn in this module
 
-This module will provide an introduction to traffic management within the Service Mesh, demonstrating some of these capabilities through the use of our existing example and the visualisation present in the Kiali Console.
+This module will provide an introduction to traffic management within the
+Service Mesh, demonstrating some of these capabilities through the use of our
+existing example and the visualisation present in the Kiali Console.
 
 === Before we begin
 
-Before starting this module you should ensure you have access to the Kiali Console and have selected the Graph tab as discussed previously, this visualisation will be used to highlight the change in behaviour as we work through this module.
+Before starting this module you should ensure you have access to the Kiali
+Console and have selected the Graph tab as discussed previously, this
+visualisation will be used to highlight the change in behaviour as we work
+through this module.
 
-We also need to check the current Service Mesh configuration is as expected.  To check the configuration run the following command
+We also need to check the current Service Mesh configuration is as expected.
+To check the configuration run the following command
 
-`oc get istio-io -n istio-tutorial`
+[source,bash,role="copypaste"]
+----
+oc get istio-io -n istio-tutorial
+----
 
-and check for output similar to the following.
+and check for output similar to the following:
 
 ----
 NAME      AGE
@@ -29,9 +41,17 @@ customer-gateway   35h
 
 === How does traffic management work within the Service Mesh?
 
-Every pod deployed as part of the Service Mesh contains a proxy container responsible for intercepting the application traffic coming into and going out of the pod.  When the application invokes a service the client side proxy will intercept the invocation and determine which server side endpoint will be invoked based on the declarative rules in force at the time of the invocation.  The default behaviour is to distribute requests to each endpoint of a service using a _Round Robin_ load balancer.  In our Recommendation service requests will be distributed across the v1, v2 and v3 endpoints.
+Every pod deployed as part of the Service Mesh contains a proxy container
+responsible for intercepting the application traffic coming into and going
+out of the pod. When the application invokes a service the client side proxy
+will intercept the invocation and determine which server side endpoint will
+be invoked based on the declarative rules in force at the time of the
+invocation. The default behaviour is to distribute requests to each endpoint
+of a service using a _Round Robin_ load balancer. In our Recommendation
+service requests will be distributed across the v1, v2 and v3 endpoints.
 
-When configuring traffic management rules there are two resources which need to be configured, these are
+When configuring traffic management rules there are two resources which need
+to be configured, these are:
 
 * The _Virtual Service_ specifying the routing rules to apply when the host is addressed.  These routing rules can include
 ** Routing to specific destinations
@@ -47,23 +67,33 @@ We will cover some of these details as we work through this module.
 
 === Generating load
 
-Before we work through some of the routing scenarios we need to first generate load on the services.  From within a terminal enter the following command
+Before we work through some of the routing scenarios we need to first
+generate load on the services. From within a terminal enter the following
+command
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ export INGRESS_GATEWAY=$(oc get route -n istio-system istio-ingressgateway -o 'jsonpath={.spec.host}')
-$ while : ; do curl http://${INGRESS_GATEWAY}/ ; sleep 1 ; done
+export INGRESS_GATEWAY=$(oc get route -n istio-system istio-ingressgateway -o 'jsonpath={.spec.host}')
+while : ; do curl http://${INGRESS_GATEWAY}/ ; sleep 1 ; done
 ----
 
-We will leave this running for the remainder of this module.  Switch over to the Kiali Console and make sure you are seeing traffic split roughly _33%_ to each of the recommendation endpoints, if you do not see any change then press the _refresh_ button in the top right of the Kiali Console.
+We will leave this running for the remainder of this module. Switch over to
+the Kiali Console and make sure you are seeing traffic split roughly _33%_ to
+each of the recommendation endpoints, if you do not see any change then press
+the _refresh_ button in the top right of the Kiali Console.
 
 image:routing-graph-1.png[Kiali showing traffic distributed across three endpoints]
 
 == Weighted Routing with the Service Mesh
 
-In this example we will modify the default behaviour for distributing requests between the endpoints however before we can do this we need to define our _Destination Rule_ and specify the endpoint subsets we would like to use.  For our demonstration we will use the version labels on each endpoint and name the subsets version-v1, version-v2 and version-v3.
+In this example we will modify the default behaviour for distributing
+requests between the endpoints however before we can do this we need to
+define our _Destination Rule_ and specify the endpoint subsets we would like
+to use. For our demonstration we will use the version labels on each endpoint
+and name the subsets version-v1, version-v2 and version-v3.
 
-NOTE: We will be using this DestinationRule for the remainder of the examples within this module
+NOTE: We will be using this DestinationRule for the remainder of the examples
+within this module
 
 [source,yaml]
 ----
@@ -85,9 +115,15 @@ spec:
     name: version-v3
 ----
 
-With the subsets now defined we can take a look at the _Virtual Service_ and how to specify different weighting across the subsets.  This feature will allow you to better control the distribution of all requests across the endpoints, for example when deploying a new version of a service where you may only wish to send a small percentage of the requests to that service to see how it reacts to live traffic.
+With the subsets now defined we can take a look at the _Virtual Service_ and
+how to specify different weighting across the subsets. This feature will
+allow you to better control the distribution of all requests across the
+endpoints, for example when deploying a new version of a service where you
+may only wish to send a small percentage of the requests to that service to
+see how it reacts to live traffic.
 
-In this example we will start by specifying _80%_ of traffic to the v1 endpoint and _20%_ of traffic to the v2 endpoint.
+In this example we will start by specifying _80%_ of traffic to the v1
+endpoint and _20%_ of traffic to the v2 endpoint.
 
 [source,yaml]
 ----
@@ -112,48 +148,84 @@ spec:
 
 === Deploying the Weighted Routing configuration
 
-To deploy this configuration into the Service Mesh switch to a terminal and execute the following command
+To deploy this configuration into the Service Mesh, open a new terminal and
+execute the following command:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc create -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-weighted.yaml
+alias oc=oc4
+oc login -u kubeadmin -p {{ KUBEADMIN_PASSWORD }} {{ API_URL }}
+oc create -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-weighted.yaml
 ----
 
-Switch over to the Kiali console to watch the traffic shifting from the original distribution to roughly _80%_ v1 and _20%_ v2.
+Switch over to the Kiali console to watch the traffic shifting from the
+original distribution to roughly _80%_ v1 and _20%_ v2.
 
 image:routing-graph-2.png[Kiali showing traffic distributed 80/20 across v1 and v2 endpoints]
 
 === Modifying the Weighted Routing configuration
 
-The weighting can be modified dynamically to further shift traffic.  For example now we know v2 is working we have decided to shift more traffic to that service
+The weighting can be modified dynamically to further shift traffic. For
+example now we know v2 is working we have decided to shift more traffic to
+that service
 
-Switch to the terminal and execute the following command
-[source,bash]
-----
-$ oc edit VirtualService recommendation -n istio-tutorial
-----
-Within the editor update the weight of the version-v1 destination to _20_ and the weight of the version-v2 destination to _80_.
+Switch to the terminal and execute the following command:
 
-Switch back to the kiali console and watch the traffic shift towards to v2 service.
+[NOTE]
+====
+This will open the default system editor which is likely Vi/M. If you prefer
+to use a different editor, make sure you do something like:
+
+[source,bash,role="copypaste"]
+----
+export EDITOR=nano
+----
+
+Or substitute whatever installed editor you like.
+====
+
+//TODO change to oc patch or similar
+[source,bash,role="copypaste"]
+----
+oc edit VirtualService recommendation -n istio-tutorial
+----
+
+Within the editor update the weight of the version-v1 destination to _20_ and
+the weight of the version-v2 destination to _80_.
+
+Switch back to the kiali console and watch the traffic shift towards to v2
+service.
 
 === Cleaning up
 
 Switch to the terminal and execute the following command
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc delete -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-weighted.yaml
+oc delete -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-weighted.yaml
 ----
 
-The traffic should now return to the default distribution with roughly 33% going to each endpoint.
+The traffic should now return to the default distribution with roughly 33%
+going to each endpoint.
 
 == Canary Releases with the Service Mesh
 
-In the previous example we modified the default behaviour for distributing requests between the endpoints so we could send traffic to particular endpoints based on weighting.  In this example we will modify the behaviour to be more selective, using characteristics of the individual request to determine which endpoint should receive the request and thereby support release strategies such as Canary Releases.
+In the previous example we modified the default behaviour for distributing
+requests between the endpoints so we could send traffic to particular
+endpoints based on weighting. In this example we will modify the behaviour to
+be more selective, using characteristics of the individual request to
+determine which endpoint should receive the request and thereby support
+release strategies such as Canary Releases.
 
-As with the last example we need to define two resources, the _Destination Rule_ and the _Virtual Service_.  We will use the same Destination Rule as in the previous example to define the individual subsets and will create a new Virtual Service to identify those requests destined for version v2.
+As with the last example we need to define two resources, the _Destination
+Rule_ and the _Virtual Service_. We will use the same Destination Rule as in
+the previous example to define the individual subsets and will create a new
+Virtual Service to identify those requests destined for version v2.
 
-For the purpose of this example we will assume our application includes a header identifying the location of the caller.  We will use this header to send everyone from the _Boston_ office to endpoint v2 while sending the remaining requests to endpoint v1.
+For the purpose of this example we will assume our application includes a
+header identifying the location of the caller. We will use this header to
+send everyone from the _Boston_ office to endpoint v2 while sending the
+remaining requests to endpoint v1.
 
 The _Virtual Service_ for this configuration is as follows
 
@@ -183,51 +255,73 @@ spec:
 
 === Deploying the Canary Release configuration
 
-To deploy this configuration into the Service Mesh switch to a terminal and execute the following command
+To deploy this configuration into the Service Mesh switch to a terminal and
+execute the following command:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc create -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-canary.yaml
+oc create -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-canary.yaml
 ----
 
-Switch back to the terminal running the load script and you will notice the responses are only coming from the v1 endpoint and we are no longer seeing replies from the v2 nor v3 endpoints.  This is the behaviour for all requests which are not marked as coming from the Boston office.
+Switch back to the terminal running the load script and you will notice the
+responses are only coming from the v1 endpoint and we are no longer seeing
+replies from the v2 nor v3 endpoints. This is the behaviour for all requests
+which are not marked as coming from the Boston office.
 
 === Verifying the Canary Release configuration
 
-To see the effect of the Canary Release routing we need to craft a request with the appropriate header indicating the request is coming from the Boston office.
+To see the effect of the Canary Release routing we need to craft a request
+with the appropriate header indicating the request is coming from the Boston
+office.
 
-Switch to a terminal and execute the following commands
+Switch to a terminal and execute the following commands:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ export INGRESS_GATEWAY=$(oc get route -n istio-system istio-ingressgateway -o 'jsonpath={.spec.host}')
-$ curl -H "user-location: Boston" http://${INGRESS_GATEWAY}/
+export INGRESS_GATEWAY=$(oc get route -n istio-system istio-ingressgateway -o 'jsonpath={.spec.host}')
+curl -H "user-location: Boston" http://${INGRESS_GATEWAY}/
 ----
 
-Note the response from the above command is returned from the v2 endpoint.  Now try different values for the header and note the responses all come from the v1 endpoint.
+Note the response from the above command is returned from the v2 endpoint.
+Now try different values for the header and note the responses all come from
+the v1 endpoint.
 
 === Cleaning up
 
-Switch to the terminal and execute the following command
+Switch to the terminal and execute the following command:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc delete -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-canary.yaml
+oc delete -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-canary.yaml
 ----
 
-The traffic should now return to the default distribution with roughly 33% going to each endpoint.
+The traffic should now return to the default distribution with roughly 33%
+going to each endpoint.
 
 == Mirroring Traffic with the Service Mesh
 
-In this example we will modify the default behaviour for distributing requests between the endpoints to send all traffic to the v2 endpoint and then use the Service Mesh's routing capabilities to mirror the traffic to the v3 endpoint.
+In this example we will modify the default behaviour for distributing
+requests between the endpoints to send all traffic to the v2 endpoint and
+then use the Service Mesh's routing capabilities to mirror the traffic to the
+v3 endpoint.
 
-Traffic mirroring is useful when you wish to test a new version of a service with live traffic while isolating the service client from the responses returned by the new endpoint.
+Traffic mirroring is useful when you wish to test a new version of a service
+with live traffic while isolating the service client from the responses
+returned by the new endpoint.
 
-Traffic mirroring works by sending the request to the original endpoint, in our example v2, while also sending a copy of the request to another endpoint, in our example v3.  The responses returned to the client will come from the original endpoint (v2) whereas responses from the mirror endpoint (v3) will be ignored.
+Traffic mirroring works by sending the request to the original endpoint, in
+our example v2, while also sending a copy of the request to another endpoint,
+in our example v3. The responses returned to the client will come from the
+original endpoint (v2) whereas responses from the mirror endpoint (v3) will
+be ignored.
 
-As with the last example we need to define two resources, the _Destination Rule_ and the _Virtual Service_.  We will use the same Destination Rule as in the previous examples to define the individual subsets and will create a new Virtual Service to set the v2 endpoint as default and mirror traffic to the v3 endpoint.
+As with the last example we need to define two resources, the _Destination
+Rule_ and the _Virtual Service_. We will use the same Destination Rule as in
+the previous examples to define the individual subsets and will create a new
+Virtual Service to set the v2 endpoint as default and mirror traffic to the
+v3 endpoint.
 
-The _Virtual Service_ for this configuration is as follows
+The _Virtual Service_ for this configuration is as follows:
 
 [source,yaml]
 ----
@@ -250,55 +344,78 @@ spec:
 
 === Before we start
 
-Before deploying this configuration switch back to the terminal running the load script and notice the responses are coming from all three endpoints for the recommendation service.  Now switch to another terminal and execute the following command to watch the console of the v3 endpoint
+Before deploying this configuration switch back to the terminal running the
+load script and notice the responses are coming from all three endpoints for
+the recommendation service. Now switch to another terminal and execute the
+following command to watch the console of the v3 endpoint:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc logs -n istio-tutorial -c recommendation -f $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v3' -o jsonpath='{..metadata.name}')
+alias oc=oc4
+oc login -u kubeadmin -p {{ KUBEADMIN_PASSWORD }} {{ API_URL }}
+oc logs -n istio-tutorial -c recommendation -f $(oc get pod -n istio-tutorial -l 'app=recommendation,version=v3' -o jsonpath='{..metadata.name}')
 ----
 
-Notice the v3 endpoint is responding to a request every three seconds, this corresponds to the request from the load script seeing the v3 responses.  Keep both scripts running while we walk through this example.
+Notice the v3 endpoint is responding to a request every three seconds, this
+corresponds to the request from the load script seeing the v3 responses. Keep
+both scripts running while we walk through this example.
 
 === Deploying the Mirroring Traffic configuration
 
-To deploy this configuration into the Service Mesh switch to a terminal and execute the following command
+To deploy this configuration into the Service Mesh switch to a terminal and
+execute the following command:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc create -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-mirroring.yaml
+oc create -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-mirroring.yaml
 ----
 
-Switch back to the terminal running the load script and you will notice the responses are only coming from the v2 endpoint with no responses coming from the v1 nor v3 endpoints.
+Switch back to the terminal running the load script and you will notice the
+responses are only coming from the v2 endpoint with no responses coming from
+the v1 nor v3 endpoints.
 
-Now switch to the terminal watching the v3 console and notice the v3 endpoint is receiving a request every second, this request is a mirror of the traffic being sent to v1.
+Now switch to the terminal watching the v3 console and notice the v3 endpoint
+is receiving a request every second, this request is a mirror of the traffic
+being sent to v1.
 
-Finally switch to the Kiali console and notice all the traffic in the _Graph_ tab has shifted across to the v2 endpoint.  Kiali shows only the normal traffic flow for the application and not the mirrored traffic.
+Finally switch to the Kiali console and notice all the traffic in the _Graph_
+tab has shifted across to the v2 endpoint. Kiali shows only the normal
+traffic flow for the application and not the mirrored traffic.
 
 image:routing-graph-3.png[Kiali showing traffic to the v2 endpoint with no mirrored traffic visible]
 
 === Cleaning up
 
-Switch back to the terminal monitoring the v3 console and press the ctrl+c keys to terminate the script.
+Switch back to the terminal monitoring the v3 console and press the ctrl+c
+keys to terminate the script.
 
-From within the same terminal execute the following command
+From within the same terminal execute the following command:
 
-[source,bash]
+[source,bash,role="copypaste"]
 ----
-$ oc delete -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-mirroring.yaml
+oc delete -n istio-tutorial -f https://raw.githubusercontent.com/thoraxe/istio-lab-summit-2019/master/src/istiofiles/routing-mirroring.yaml
 ----
 
-The traffic should now return to the default distribution with roughly 33% going to each endpoint.
+The traffic should now return to the default distribution with roughly 33%
+going to each endpoint.
 
-Switch back to the terminal with the script we used to generate load and press the ctrl+c keys to terminate the script.
+Switch back to the terminal with the script we used to generate load and
+press the ctrl+c keys to terminate the script.
 
 == What we learned in this module
 
-In this module we learned how to manage the traffic in our application through the declaration of routing rules deployed as Service Mesh _Destination Rule_ and _Virtual Service_ resources.  This change in routing behaviour was managed without any modifications to the application's code and without the application being aware these changes were occurring.
+In this module we learned how to manage the traffic in our application
+through the declaration of routing rules deployed as Service Mesh
+_Destination Rule_ and _Virtual Service_ resources. This change in routing
+behaviour was managed without any modifications to the application's code and
+without the application being aware these changes were occurring.
 
-We learned
+We learned:
 
 * how to distribute requests across a number of services using weighting
 * how to distribute requests based on specific characteristics of the incoming request
 * how to mirror traffic from one endpoint to another.
 
-The Service Mesh traffic management capabilities support the declaration of more complex routing behaviour.  This module is designed to provide only a small taste of what is possible.
+The Service Mesh traffic management capabilities support the declaration of
+more complex routing behaviour. This module is designed to provide only a
+small taste of what is possible.


### PR DESCRIPTION
I made a lot of changes to match some "style standards" like using the `copypaste` role on blocks, not adding `$` or `#` to commands, etc.

I did not change any actual commands.

I also tweaked some blocks that had `bash` and not `yaml`.

This should not materially affect any labs.